### PR TITLE
feat: add services page with tile component and toolbar commands

### DIFF
--- a/apps/frontend/src/app/app.config.ts
+++ b/apps/frontend/src/app/app.config.ts
@@ -1,6 +1,6 @@
 import { ApplicationConfig, provideBrowserGlobalErrorListeners } from '@angular/core';
 import { provideRouter } from '@angular/router';
-import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClient, withInterceptors } from '@angular/common/http';
 import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
 import { provideStore } from '@ngrx/store';
 import { provideEffects } from '@ngrx/effects';
@@ -8,6 +8,9 @@ import { provideEffects } from '@ngrx/effects';
 import { appRoutes } from './app.routes';
 import { authReducer } from './auth/store/auth.reducer';
 import { AuthEffects } from './auth/store/auth.effects';
+import { servicesReducer } from './services/store/services.reducer';
+import { ServicesEffects } from './services/store/services.effects';
+import { authInterceptor } from './core/interceptors/auth.interceptor';
 import { APP_VERSION } from './core/tokens/app.tokens';
 import { version } from '../../../../package.json';
 
@@ -15,10 +18,10 @@ export const appConfig: ApplicationConfig = {
   providers: [
     provideBrowserGlobalErrorListeners(),
     provideRouter(appRoutes),
-    provideHttpClient(),
+    provideHttpClient(withInterceptors([authInterceptor])),
     provideAnimationsAsync(),
-    provideStore({ auth: authReducer }),
-    provideEffects([AuthEffects]),
+    provideStore({ auth: authReducer, services: servicesReducer }),
+    provideEffects([AuthEffects, ServicesEffects]),
     { provide: APP_VERSION, useValue: version },
   ],
 };

--- a/apps/frontend/src/app/app.routes.ts
+++ b/apps/frontend/src/app/app.routes.ts
@@ -1,4 +1,5 @@
 import { Route } from '@angular/router';
+import { authGuard } from './core/guards/auth.guard';
 
 export const appRoutes: Route[] = [
   { path: '', redirectTo: 'login', pathMatch: 'full' },
@@ -7,7 +8,12 @@ export const appRoutes: Route[] = [
     loadComponent: () =>
       import('./auth/login/login.component').then((m) => m.LoginComponent),
   },
-  // { path: 'services', loadComponent: () => import('./services/services.component').then(m => m.ServicesComponent) },
-  // { path: 'editor/:id/:page', loadComponent: () => import('./editor/editor.component').then(m => m.EditorComponent) },
-  // { path: 'monitor/:id', loadComponent: () => import('./monitor/monitor.component').then(m => m.MonitorComponent) },
+  {
+    path: 'services',
+    canActivate: [authGuard],
+    loadComponent: () =>
+      import('./services/services.component').then((m) => m.ServicesComponent),
+  },
+  // { path: 'editor/:id/:page', loadComponent: () => import('./editor/editor.component').then(m => m.EditorComponent), canActivate: [authGuard] },
+  // { path: 'monitor/:id', loadComponent: () => import('./monitor/monitor.component').then(m => m.MonitorComponent), canActivate: [authGuard] },
 ];

--- a/apps/frontend/src/app/auth/store/auth.effects.ts
+++ b/apps/frontend/src/app/auth/store/auth.effects.ts
@@ -49,4 +49,13 @@ export class AuthEffects {
       ),
     { dispatch: false },
   );
+
+  logout$ = createEffect(
+    () =>
+      this.actions$.pipe(
+        ofType(AuthActions.logout),
+        tap(() => this.router.navigate(['/login'])),
+      ),
+    { dispatch: false },
+  );
 }

--- a/apps/frontend/src/app/core/components/confirm-dialog/confirm-dialog.component.ts
+++ b/apps/frontend/src/app/core/components/confirm-dialog/confirm-dialog.component.ts
@@ -1,0 +1,44 @@
+import { Component, inject } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+import {
+  MatDialogModule,
+  MAT_DIALOG_DATA,
+  MatDialogRef,
+} from '@angular/material/dialog';
+
+export interface ConfirmDialogData {
+  title: string;
+  message: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+}
+
+@Component({
+  selector: 'vs-confirm-dialog',
+  standalone: true,
+  imports: [MatButtonModule, MatDialogModule],
+  template: `
+    <h2 mat-dialog-title>{{ data.title }}</h2>
+    <mat-dialog-content>{{ data.message }}</mat-dialog-content>
+    <mat-dialog-actions align="end">
+      <button mat-button (click)="cancel()">
+        {{ data.cancelLabel ?? 'Cancel' }}
+      </button>
+      <button mat-button color="warn" (click)="confirm()">
+        {{ data.confirmLabel ?? 'Confirm' }}
+      </button>
+    </mat-dialog-actions>
+  `,
+})
+export class ConfirmDialogComponent {
+  data = inject<ConfirmDialogData>(MAT_DIALOG_DATA);
+  private dialogRef = inject(MatDialogRef<ConfirmDialogComponent>);
+
+  confirm(): void {
+    this.dialogRef.close(true);
+  }
+
+  cancel(): void {
+    this.dialogRef.close(false);
+  }
+}

--- a/apps/frontend/src/app/core/components/toolbar/toolbar.component.html
+++ b/apps/frontend/src/app/core/components/toolbar/toolbar.component.html
@@ -1,27 +1,67 @@
 <mat-toolbar class="vs-toolbar" [class.narrow]="isNarrow()">
+
+  <!-- Brand -->
   <div class="brand">
-    <img
-      class="brand-logo"
-      src="assets/cloud-white.svg"
-      alt="Virtual Service"
-    />
+    <img class="brand-logo" src="assets/cloud-white.svg" alt="Virtual Service" />
     @if (!isNarrow()) {
       <div class="brand-divider"></div>
       <div class="brand-text">
         <span class="brand-title">Virtual Service</span>
-        <span class="brand-desc"
-          >build a develop web service
-          <strong class="brand-accent">REST</strong> in a few moments</span
-        >
+        <span class="brand-desc">
+          build a develop web service
+          <strong class="brand-accent">REST</strong> in a few moments
+        </span>
       </div>
     }
   </div>
 
   <span class="flex-spacer"></span>
 
-  @if (isLoggedIn()) {
+  <!-- User section (visible only when logged in) -->
+  @if (user()) {
     <div class="user-section">
-      <!-- user profile goes here -->
+      <mat-icon class="user-avatar">account_circle</mat-icon>
+
+      @if (!isNarrow()) {
+        <span class="user-name">{{ user()!.email }}</span>
+      }
+
+      @if (!isNarrow()) {
+        <!-- Wide mode: render commands as icon buttons -->
+        @for (cmd of visibleCommands(); track cmd.id) {
+          @if (cmd.type === 'separator') {
+            <div class="cmd-separator"></div>
+          } @else {
+            <button
+              mat-icon-button
+              class="cmd-btn"
+              [matTooltip]="cmd.tooltip ?? ''"
+              [disabled]="cmd.enabled === false"
+              (click)="cmd.action?.()">
+              <mat-icon>{{ cmd.icon }}</mat-icon>
+            </button>
+          }
+        }
+      } @else {
+        <!-- Narrow mode: commands in popup menu -->
+        @if (buttonCommands().length > 0) {
+          <button mat-icon-button [matMenuTriggerFor]="cmdMenu" class="cmd-btn">
+            <mat-icon>more_vert</mat-icon>
+          </button>
+          <mat-menu #cmdMenu="matMenu">
+            @for (cmd of buttonCommands(); track cmd.id) {
+              <button
+                mat-menu-item
+                [disabled]="cmd.enabled === false"
+                (click)="cmd.action?.()">
+                <mat-icon>{{ cmd.icon }}</mat-icon>
+                <span>{{ cmd.tooltip }}</span>
+              </button>
+            }
+          </mat-menu>
+        }
+      }
     </div>
   }
+
 </mat-toolbar>

--- a/apps/frontend/src/app/core/components/toolbar/toolbar.component.scss
+++ b/apps/frontend/src/app/core/components/toolbar/toolbar.component.scss
@@ -57,6 +57,47 @@
   .flex-spacer {
     flex: 1 1 auto;
   }
+
+  /* User section */
+  .user-section {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    color: var(--vs-light);
+
+    .user-avatar {
+      font-size: 28px;
+      width: 28px;
+      height: 28px;
+      line-height: 28px;
+      opacity: 0.85;
+    }
+
+    .user-name {
+      font-size: 0.85rem;
+      opacity: 0.85;
+      max-width: 160px;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .cmd-separator {
+      width: 1px;
+      height: 24px;
+      background: rgba(255, 255, 255, 0.25);
+      margin: 0 4px;
+    }
+
+    .cmd-btn {
+      color: var(--vs-light);
+      opacity: 0.85;
+
+      &:hover {
+        opacity: 1;
+      }
+    }
+  }
 }
 
 /* narrow mode */
@@ -71,5 +112,9 @@
       width: 32px;
       height: 32px;
     }
+  }
+
+  .user-section {
+    gap: 4px;
   }
 }

--- a/apps/frontend/src/app/core/components/toolbar/toolbar.component.ts
+++ b/apps/frontend/src/app/core/components/toolbar/toolbar.component.ts
@@ -1,24 +1,48 @@
-import { Component, inject, input } from '@angular/core';
+import { Component, computed, inject } from '@angular/core';
 import { MatToolbarModule } from '@angular/material/toolbar';
 import { MatIconModule } from '@angular/material/icon';
 import { MatButtonModule } from '@angular/material/button';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { MatMenuModule } from '@angular/material/menu';
 import { BreakpointObserver } from '@angular/cdk/layout';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { map } from 'rxjs';
+import { Store } from '@ngrx/store';
+import { selectUser } from '../../../auth/store/auth.selectors';
+import { ToolbarService } from '../../services/toolbar.service';
 
 @Component({
   selector: 'vs-toolbar',
   standalone: true,
-  imports: [MatToolbarModule, MatIconModule, MatButtonModule],
+  imports: [
+    MatToolbarModule,
+    MatIconModule,
+    MatButtonModule,
+    MatTooltipModule,
+    MatMenuModule,
+  ],
   templateUrl: './toolbar.component.html',
   styleUrl: './toolbar.component.scss',
 })
 export class ToolbarComponent {
-  isLoggedIn = input<boolean>(false);
-
   private breakpoints = inject(BreakpointObserver);
+  private store = inject(Store);
+  private toolbarService = inject(ToolbarService);
+
   isNarrow = toSignal(
     this.breakpoints.observe('(max-width: 800px)').pipe(map((r) => r.matches)),
     { initialValue: false },
+  );
+
+  user = this.store.selectSignal(selectUser);
+
+  commands = this.toolbarService.commands;
+
+  visibleCommands = computed(() =>
+    this.commands().filter((c) => c.visible !== false),
+  );
+
+  buttonCommands = computed(() =>
+    this.visibleCommands().filter((c) => c.type !== 'separator'),
   );
 }

--- a/apps/frontend/src/app/core/guards/auth.guard.ts
+++ b/apps/frontend/src/app/core/guards/auth.guard.ts
@@ -1,0 +1,17 @@
+import { inject } from '@angular/core';
+import { CanActivateFn, Router } from '@angular/router';
+import { Store } from '@ngrx/store';
+import { map, take } from 'rxjs';
+import { selectIsLoggedIn } from '../../auth/store/auth.selectors';
+
+export const authGuard: CanActivateFn = () => {
+  const store = inject(Store);
+  const router = inject(Router);
+
+  return store.select(selectIsLoggedIn).pipe(
+    take(1),
+    map((isLoggedIn) =>
+      isLoggedIn ? true : router.createUrlTree(['/login']),
+    ),
+  );
+};

--- a/apps/frontend/src/app/core/interceptors/auth.interceptor.ts
+++ b/apps/frontend/src/app/core/interceptors/auth.interceptor.ts
@@ -1,0 +1,22 @@
+import { inject } from '@angular/core';
+import { HttpInterceptorFn } from '@angular/common/http';
+import { Store } from '@ngrx/store';
+import { selectToken } from '../../auth/store/auth.selectors';
+import { take, switchMap } from 'rxjs';
+
+export const authInterceptor: HttpInterceptorFn = (req, next) => {
+  const store = inject(Store);
+
+  return store.select(selectToken).pipe(
+    take(1),
+    switchMap((token) => {
+      if (token) {
+        const authReq = req.clone({
+          headers: req.headers.set('Authorization', `Bearer ${token}`),
+        });
+        return next(authReq);
+      }
+      return next(req);
+    }),
+  );
+};

--- a/apps/frontend/src/app/core/models/toolbar-command.model.ts
+++ b/apps/frontend/src/app/core/models/toolbar-command.model.ts
@@ -1,0 +1,11 @@
+export type ToolbarCommandType = 'button' | 'separator';
+
+export interface ToolbarCommand {
+  type?: ToolbarCommandType;
+  id?: string;
+  icon?: string;
+  tooltip?: string;
+  enabled?: boolean;
+  visible?: boolean;
+  action?: () => void;
+}

--- a/apps/frontend/src/app/core/services/toolbar.service.ts
+++ b/apps/frontend/src/app/core/services/toolbar.service.ts
@@ -1,0 +1,16 @@
+import { Injectable, signal } from '@angular/core';
+import { ToolbarCommand } from '../models/toolbar-command.model';
+
+@Injectable({ providedIn: 'root' })
+export class ToolbarService {
+  private _commands = signal<ToolbarCommand[]>([]);
+  readonly commands = this._commands.asReadonly();
+
+  set(cmds: ToolbarCommand[]): void {
+    this._commands.set(cmds);
+  }
+
+  clear(): void {
+    this._commands.set([]);
+  }
+}

--- a/apps/frontend/src/app/services/service-tile/service-tile.component.html
+++ b/apps/frontend/src/app/services/service-tile/service-tile.component.html
@@ -1,0 +1,65 @@
+<mat-card class="tile" [class.inactive]="!service().active" (click)="onCardClick()">
+
+  <mat-card-header>
+    <button
+      mat-icon-button
+      class="active-btn"
+      [matTooltip]="service().active ? 'Deactivate service' : 'Activate service'"
+      (click)="onToggleActive($event)"
+    >
+      <mat-icon [class.active-icon]="service().active">
+        {{ service().active ? 'radio_button_checked' : 'radio_button_unchecked' }}
+      </mat-icon>
+    </button>
+
+    <div class="title-block">
+      <span class="service-name">{{ service().name }}</span>
+      <span class="service-date">{{ formatDate(service().lastChange) }}</span>
+    </div>
+
+    <button
+      mat-icon-button
+      color="warn"
+      class="delete-btn"
+      matTooltip="Delete service"
+      (click)="onDelete($event)"
+    >
+      <mat-icon>delete</mat-icon>
+    </button>
+  </mat-card-header>
+
+  <mat-card-content>
+    <p class="description">{{ service().description || '—' }}</p>
+    <span class="call-count">{{ service().calls.length }} calls</span>
+  </mat-card-content>
+
+  <mat-card-actions>
+    <div class="left-actions">
+      <button
+        mat-icon-button
+        matTooltip="Open service calls monitor"
+        [disabled]="!service().active"
+        (click)="onMonitor($event)"
+      >
+        <mat-icon>desktop_windows</mat-icon>
+      </button>
+      <button
+        mat-icon-button
+        matTooltip="Download swagger"
+        (click)="onDownloadSwagger($event)"
+      >
+        <mat-icon>get_app</mat-icon>
+      </button>
+      <button
+        mat-icon-button
+        [matTooltip]="service().starred ? 'Remove from favorites' : 'Add to favorites'"
+        (click)="onToggleStarred($event)"
+      >
+        <mat-icon>{{ service().starred ? 'star' : 'star_border' }}</mat-icon>
+      </button>
+    </div>
+    <span class="flex-spacer"></span>
+    <button mat-stroked-button (click)="onOpen($event)">OPEN</button>
+  </mat-card-actions>
+
+</mat-card>

--- a/apps/frontend/src/app/services/service-tile/service-tile.component.scss
+++ b/apps/frontend/src/app/services/service-tile/service-tile.component.scss
@@ -1,0 +1,131 @@
+:host {
+  display: block;
+  width: 250px;
+  flex-shrink: 0;
+}
+
+.tile {
+  width: 250px;
+  cursor: pointer;
+  box-shadow: none !important;
+  transition: box-shadow 200ms ease;
+  background: white;
+
+  &:hover {
+    box-shadow:
+      0 2px 4px -1px rgba(0, 0, 0, 0.2),
+      0 4px 5px 0 rgba(0, 0, 0, 0.14),
+      0 1px 10px 0 rgba(0, 0, 0, 0.12) !important;
+  }
+
+  &.inactive {
+    background: repeating-linear-gradient(
+      45deg,
+      #f8f8ff,
+      #f8f8ff 10px,
+      rgba(200, 200, 200, 0.1) 10px,
+      rgba(200, 200, 200, 0.1) 20px
+    ) !important;
+  }
+}
+
+/* Override Material header layout */
+::ng-deep .tile .mat-mdc-card-header {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 4px;
+  padding: 8px 8px 0;
+
+  .mat-mdc-card-header-text {
+    display: none;
+  }
+}
+
+.title-block {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+
+  .service-name {
+    font-size: 0.95rem;
+    font-weight: 700;
+    color: var(--vs-dark);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .service-date {
+    font-size: 0.75rem;
+    color: rgba(38, 50, 56, 0.6);
+    margin-top: 2px;
+  }
+}
+
+.active-btn {
+  flex-shrink: 0;
+
+  .active-icon {
+    color: var(--vs-primary);
+  }
+}
+
+.delete-btn {
+  flex-shrink: 0;
+}
+
+mat-card-content {
+  padding: 8px 16px;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+
+  .description {
+    font-size: 0.8rem;
+    color: var(--vs-dark);
+    margin: 0 0 8px;
+    flex: 1;
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
+    min-height: 3.6em;
+  }
+
+  .call-count {
+    font-size: 0.75rem;
+    font-weight: 500;
+    color: var(--vs-accent-light);
+    margin-top: auto;
+  }
+}
+
+mat-card-actions {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  padding: 4px 8px;
+
+  .left-actions {
+    display: flex;
+    align-items: center;
+  }
+
+  .flex-spacer {
+    flex: 1 1 auto;
+  }
+}
+
+/* Narrow mode: scale down */
+@media only screen and (max-width: 800px) {
+  :host {
+    width: 220px;
+    zoom: 0.8;
+  }
+
+  .tile {
+    width: 220px;
+  }
+}

--- a/apps/frontend/src/app/services/service-tile/service-tile.component.ts
+++ b/apps/frontend/src/app/services/service-tile/service-tile.component.ts
@@ -1,0 +1,91 @@
+import { Component, inject, input, output } from '@angular/core';
+import { MatCardModule } from '@angular/material/card';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { MatDialog, MatDialogModule } from '@angular/material/dialog';
+import {
+  ConfirmDialogComponent,
+  ConfirmDialogData,
+} from '../../core/components/confirm-dialog/confirm-dialog.component';
+import { IServiceItem } from '../store/services.state';
+
+@Component({
+  selector: 'vs-service-tile',
+  standalone: true,
+  imports: [
+    MatCardModule,
+    MatButtonModule,
+    MatIconModule,
+    MatTooltipModule,
+    MatDialogModule,
+  ],
+  templateUrl: './service-tile.component.html',
+  styleUrl: './service-tile.component.scss',
+})
+export class ServiceTileComponent {
+  service = input.required<IServiceItem>();
+
+  toggleActive = output<IServiceItem>();
+  toggleStarred = output<IServiceItem>();
+  delete = output<string>();
+  open = output<string>();
+  monitor = output<string>();
+  downloadSwagger = output<string>();
+
+  private dialog = inject(MatDialog);
+
+  formatDate(timestamp: number): string {
+    const d = new Date(timestamp);
+    const day = d.getDate().toString().padStart(2, '0');
+    const month = (d.getMonth() + 1).toString().padStart(2, '0');
+    const year = d.getFullYear();
+    return `${day}/${month}/${year}`;
+  }
+
+  onCardClick(): void {
+    this.open.emit(this.service()._id);
+  }
+
+  onToggleActive(event: Event): void {
+    event.stopPropagation();
+    const s = this.service();
+    this.toggleActive.emit({ ...s, active: !s.active });
+  }
+
+  onToggleStarred(event: Event): void {
+    event.stopPropagation();
+    const s = this.service();
+    this.toggleStarred.emit({ ...s, starred: !s.starred });
+  }
+
+  onDelete(event: Event): void {
+    event.stopPropagation();
+    const data: ConfirmDialogData = {
+      title: 'Delete Service',
+      message: `Delete "${this.service().name}"? This action cannot be undone.`,
+      confirmLabel: 'Delete',
+    };
+    const ref = this.dialog.open(ConfirmDialogComponent, { data });
+    ref.afterClosed().subscribe((confirmed: boolean) => {
+      if (confirmed) {
+        this.delete.emit(this.service()._id);
+      }
+    });
+  }
+
+  onOpen(event: Event): void {
+    event.stopPropagation();
+    this.open.emit(this.service()._id);
+  }
+
+  onMonitor(event: Event): void {
+    event.stopPropagation();
+    this.monitor.emit(this.service()._id);
+  }
+
+  onDownloadSwagger(event: Event): void {
+    event.stopPropagation();
+    this.downloadSwagger.emit(this.service()._id);
+  }
+}

--- a/apps/frontend/src/app/services/services.component.html
+++ b/apps/frontend/src/app/services/services.component.html
@@ -1,0 +1,96 @@
+<div
+  class="services-page"
+  [class.drag-over]="isDragOver"
+  (dragover)="onDragOver($event)"
+  (dragleave)="onDragLeave($event)"
+  (drop)="onDrop($event)"
+>
+
+  <!-- Background drop hint (always visible, behind content) -->
+  <div class="drop-hint">
+    <span class="drop-hint-label">drop a file of one of the following types here</span>
+    <span class="drop-hint-types">
+      curl text file (bash style) &nbsp;·&nbsp;
+      chrome log (.har) &nbsp;·&nbsp;
+      swagger (SOA 2.0) &nbsp;·&nbsp;
+      postman (collection v2)
+    </span>
+  </div>
+
+  <!-- Main scrollable content -->
+  <div class="services-content">
+
+    @if (loading()) {
+      <div class="loading-overlay">
+        <mat-spinner diameter="48"></mat-spinner>
+      </div>
+    }
+
+    @if (error()) {
+      <div class="error-banner">{{ error() }}</div>
+    }
+
+    <!-- Starred section -->
+    @if (starredServices().length > 0) {
+      <section class="services-section starred-section">
+        <mat-icon class="section-icon">star</mat-icon>
+        <div class="tiles-grid">
+          @for (svc of starredServices(); track svc._id) {
+            <vs-service-tile
+              [service]="svc"
+              (toggleActive)="onToggleActive($event)"
+              (toggleStarred)="onToggleStarred($event)"
+              (delete)="onDeleteService($event)"
+              (open)="onOpenService($event)"
+              (monitor)="onMonitorService($event)"
+              (downloadSwagger)="onDownloadSwagger($event)"
+            />
+          }
+        </div>
+      </section>
+      <hr class="section-divider" />
+    }
+
+    <!-- All other services section -->
+    <section class="services-section other-section">
+      <mat-icon class="section-icon">toll</mat-icon>
+      <div class="tiles-grid">
+        @for (svc of otherServices(); track svc._id) {
+          <vs-service-tile
+            [service]="svc"
+            (toggleActive)="onToggleActive($event)"
+            (toggleStarred)="onToggleStarred($event)"
+            (delete)="onDeleteService($event)"
+            (open)="onOpenService($event)"
+            (monitor)="onMonitorService($event)"
+            (downloadSwagger)="onDownloadSwagger($event)"
+          />
+        }
+        @if (otherServices().length === 0 && starredServices().length === 0 && !loading()) {
+          <p class="empty-label">No services yet. Click <strong>+</strong> to create one.</p>
+        }
+      </div>
+    </section>
+
+  </div>
+
+  <!-- Bottom FAB toolbar -->
+  <div class="bottom-fab-bar">
+    <button
+      mat-fab
+      matTooltip="Open help page"
+      (click)="onGoToHelp()"
+    >
+      <mat-icon>help_outline</mat-icon>
+    </button>
+    <button
+      mat-fab
+      color="accent"
+      matTooltip="Create new service"
+      (click)="onCreateService()"
+    >
+      <mat-icon>add</mat-icon>
+    </button>
+  </div>
+
+</div>

--- a/apps/frontend/src/app/services/services.component.scss
+++ b/apps/frontend/src/app/services/services.component.scss
@@ -1,0 +1,143 @@
+:host {
+  display: block;
+  height: 100%;
+}
+
+.services-page {
+  position: relative;
+  min-height: calc(100vh - var(--toolbar-height-wide));
+  background: var(--vs-light);
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+
+/* Drop hint — absolute, centered at bottom, behind content */
+.drop-hint {
+  position: fixed;
+  bottom: 80px;
+  left: 0;
+  right: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  pointer-events: none;
+  z-index: 0;
+
+  .drop-hint-label {
+    font-size: 0.875rem;
+    color: rgba(38, 50, 56, 0.2);
+    text-align: center;
+  }
+
+  .drop-hint-types {
+    font-size: 0.75rem;
+    color: rgba(38, 50, 56, 0.15);
+    text-align: center;
+  }
+}
+
+/* Highlight drop zone on drag-over */
+.services-page.drag-over .drop-hint {
+  .drop-hint-label,
+  .drop-hint-types {
+    color: var(--vs-primary);
+    opacity: 0.6;
+  }
+}
+
+/* Main content */
+.services-content {
+  position: relative;
+  z-index: 1;
+  padding: 24px 24px 100px;
+}
+
+.loading-overlay {
+  display: flex;
+  justify-content: center;
+  padding: 48px;
+}
+
+.error-banner {
+  background: var(--vs-warn-light);
+  color: white;
+  padding: 12px 16px;
+  border-radius: 4px;
+  margin-bottom: 16px;
+  font-size: 0.875rem;
+}
+
+/* Service sections */
+.services-section {
+  position: relative;
+  padding: 16px 0;
+
+  .section-icon {
+    position: absolute;
+    top: 16px;
+    right: 8px;
+    font-size: 100px;
+    width: 100px;
+    height: 100px;
+    line-height: 100px;
+    color: rgba(38, 50, 56, 0.06);
+    pointer-events: none;
+    user-select: none;
+  }
+}
+
+/* Tiles grid */
+.tiles-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  align-items: flex-start;
+}
+
+.empty-label {
+  font-size: 0.875rem;
+  color: rgba(38, 50, 56, 0.5);
+  padding: 16px 0;
+}
+
+/* Section separator */
+.section-divider {
+  border: none;
+  border-top: 1px solid rgba(38, 50, 56, 0.15);
+  margin: 8px 0;
+}
+
+/* Bottom FAB toolbar */
+.bottom-fab-bar {
+  position: fixed;
+  bottom: 16px;
+  right: 16px;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 12px;
+  background: transparent;
+  z-index: 10;
+}
+
+/* Narrow mode */
+@media only screen and (max-width: 800px) {
+  .services-page {
+    min-height: calc(100vh - var(--toolbar-height-narrow));
+  }
+
+  .services-content {
+    padding: 16px 12px 100px;
+  }
+
+  .tiles-grid {
+    gap: 12px;
+    justify-content: center;
+  }
+
+  .bottom-fab-bar {
+    right: 12px;
+    bottom: 12px;
+  }
+}

--- a/apps/frontend/src/app/services/services.component.ts
+++ b/apps/frontend/src/app/services/services.component.ts
@@ -1,0 +1,135 @@
+import { Component, DestroyRef, inject } from '@angular/core';
+import { Router } from '@angular/router';
+import { Store } from '@ngrx/store';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
+
+import { ToolbarService } from '../core/services/toolbar.service';
+import { ToolbarCommand } from '../core/models/toolbar-command.model';
+import { selectUser } from '../auth/store/auth.selectors';
+import { logout } from '../auth/store/auth.actions';
+import {
+  selectStarredServices,
+  selectOtherServices,
+  selectServicesLoading,
+  selectServicesError,
+} from './store/services.selectors';
+import {
+  loadServices,
+  saveService,
+  deleteService,
+  createService,
+} from './store/services.actions';
+import { IServiceItem } from './store/services.state';
+import { ServiceTileComponent } from './service-tile/service-tile.component';
+
+@Component({
+  selector: 'vs-services',
+  standalone: true,
+  imports: [
+    MatProgressSpinnerModule,
+    MatButtonModule,
+    MatIconModule,
+    MatTooltipModule,
+    MatSnackBarModule,
+    ServiceTileComponent,
+  ],
+  templateUrl: './services.component.html',
+  styleUrl: './services.component.scss',
+})
+export class ServicesComponent {
+  private store = inject(Store);
+  private router = inject(Router);
+  private toolbarService = inject(ToolbarService);
+  private snackBar = inject(MatSnackBar);
+
+  readonly loading = this.store.selectSignal(selectServicesLoading);
+  readonly error = this.store.selectSignal(selectServicesError);
+  readonly starredServices = this.store.selectSignal(selectStarredServices);
+  readonly otherServices = this.store.selectSignal(selectOtherServices);
+
+  isDragOver = false;
+
+  constructor() {
+    this.store.dispatch(loadServices());
+    this.setupToolbar();
+    inject(DestroyRef).onDestroy(() => this.toolbarService.clear());
+  }
+
+  private setupToolbar(): void {
+    const user = this.store.selectSignal(selectUser)();
+    const commands: ToolbarCommand[] = [];
+
+    if (user?.role === 'admin') {
+      commands.push({
+        id: 'management',
+        icon: 'settings',
+        tooltip: 'Management',
+        action: () => this.router.navigate(['/management']),
+      });
+      commands.push({ type: 'separator' });
+    }
+
+    commands.push({
+      id: 'logout',
+      icon: 'power_settings_new',
+      tooltip: 'Logout',
+      action: () => this.store.dispatch(logout()),
+    });
+
+    this.toolbarService.set(commands);
+  }
+
+  onToggleActive(service: IServiceItem): void {
+    this.store.dispatch(saveService({ service }));
+  }
+
+  onToggleStarred(service: IServiceItem): void {
+    this.store.dispatch(saveService({ service }));
+  }
+
+  onDeleteService(id: string): void {
+    this.store.dispatch(deleteService({ id }));
+  }
+
+  onOpenService(id: string): void {
+    this.router.navigate(['/editor', id, 'calls']);
+  }
+
+  onMonitorService(id: string): void {
+    this.router.navigate(['/monitor', id]);
+  }
+
+  onDownloadSwagger(id: string): void {
+    this.snackBar.open('Swagger download coming soon', 'Close', {
+      duration: 3000,
+    });
+  }
+
+  onCreateService(): void {
+    this.store.dispatch(createService());
+  }
+
+  onGoToHelp(): void {
+    this.router.navigate(['/help']);
+  }
+
+  onDragOver(event: DragEvent): void {
+    event.preventDefault();
+    this.isDragOver = true;
+  }
+
+  onDragLeave(event: DragEvent): void {
+    this.isDragOver = false;
+  }
+
+  onDrop(event: DragEvent): void {
+    event.preventDefault();
+    this.isDragOver = false;
+    // File parsing (curl/har/swagger/postman) — not yet implemented
+    this.snackBar.open('File import coming soon', 'Close', { duration: 3000 });
+  }
+}

--- a/apps/frontend/src/app/services/services.service.ts
+++ b/apps/frontend/src/app/services/services.service.ts
@@ -1,0 +1,21 @@
+import { inject, Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { IServiceItem } from './store/services.state';
+
+@Injectable({ providedIn: 'root' })
+export class ServicesApiService {
+  private http = inject(HttpClient);
+
+  getAll(): Observable<IServiceItem[]> {
+    return this.http.get<IServiceItem[]>('/api/services');
+  }
+
+  save(service: Partial<IServiceItem>): Observable<IServiceItem> {
+    return this.http.post<IServiceItem>('/api/services', service);
+  }
+
+  delete(id: string): Observable<void> {
+    return this.http.delete<void>(`/api/services/${id}`);
+  }
+}

--- a/apps/frontend/src/app/services/store/services.actions.ts
+++ b/apps/frontend/src/app/services/store/services.actions.ts
@@ -1,0 +1,48 @@
+import { createAction, props } from '@ngrx/store';
+import { IServiceItem } from './services.state';
+
+export const loadServices = createAction('[Services] Load');
+export const loadServicesSuccess = createAction(
+  '[Services] Load Success',
+  props<{ services: IServiceItem[] }>(),
+);
+export const loadServicesFailure = createAction(
+  '[Services] Load Failure',
+  props<{ error: string }>(),
+);
+
+export const saveService = createAction(
+  '[Services] Save',
+  props<{ service: IServiceItem }>(),
+);
+export const saveServiceSuccess = createAction(
+  '[Services] Save Success',
+  props<{ service: IServiceItem }>(),
+);
+export const saveServiceFailure = createAction(
+  '[Services] Save Failure',
+  props<{ error: string }>(),
+);
+
+export const deleteService = createAction(
+  '[Services] Delete',
+  props<{ id: string }>(),
+);
+export const deleteServiceSuccess = createAction(
+  '[Services] Delete Success',
+  props<{ id: string }>(),
+);
+export const deleteServiceFailure = createAction(
+  '[Services] Delete Failure',
+  props<{ error: string }>(),
+);
+
+export const createService = createAction('[Services] Create');
+export const createServiceSuccess = createAction(
+  '[Services] Create Success',
+  props<{ service: IServiceItem }>(),
+);
+export const createServiceFailure = createAction(
+  '[Services] Create Failure',
+  props<{ error: string }>(),
+);

--- a/apps/frontend/src/app/services/store/services.effects.ts
+++ b/apps/frontend/src/app/services/store/services.effects.ts
@@ -1,0 +1,111 @@
+import { inject, Injectable } from '@angular/core';
+import { Actions, createEffect, ofType } from '@ngrx/effects';
+import { Router } from '@angular/router';
+import { catchError, map, switchMap, tap } from 'rxjs/operators';
+import { of } from 'rxjs';
+import * as ServicesActions from './services.actions';
+import { ServicesApiService } from '../services.service';
+
+@Injectable()
+export class ServicesEffects {
+  private actions$ = inject(Actions);
+  private api = inject(ServicesApiService);
+  private router = inject(Router);
+
+  loadServices$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(ServicesActions.loadServices),
+      switchMap(() =>
+        this.api.getAll().pipe(
+          map((services) => ServicesActions.loadServicesSuccess({ services })),
+          catchError((err) =>
+            of(
+              ServicesActions.loadServicesFailure({
+                error: err.error?.message ?? 'Failed to load services',
+              }),
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+
+  saveService$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(ServicesActions.saveService),
+      switchMap(({ service }) =>
+        this.api.save(service).pipe(
+          map((saved) => ServicesActions.saveServiceSuccess({ service: saved })),
+          catchError((err) =>
+            of(
+              ServicesActions.saveServiceFailure({
+                error: err.error?.message ?? 'Failed to save service',
+              }),
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+
+  deleteService$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(ServicesActions.deleteService),
+      switchMap(({ id }) =>
+        this.api.delete(id).pipe(
+          map(() => ServicesActions.deleteServiceSuccess({ id })),
+          catchError((err) =>
+            of(
+              ServicesActions.deleteServiceFailure({
+                error: err.error?.message ?? 'Failed to delete service',
+              }),
+            ),
+          ),
+        ),
+      ),
+    ),
+  );
+
+  createService$ = createEffect(() =>
+    this.actions$.pipe(
+      ofType(ServicesActions.createService),
+      switchMap(() => {
+        const now = Date.now();
+        const newService = {
+          name: 'New Service',
+          description: '',
+          active: false,
+          starred: false,
+          path: `new-service-${now}`,
+          calls: [],
+          dbo: '',
+          schedulerFn: '',
+          interval: 0,
+          lastChange: now,
+          creationDate: now,
+        };
+        return this.api.save(newService).pipe(
+          map((saved) => ServicesActions.createServiceSuccess({ service: saved })),
+          catchError((err) =>
+            of(
+              ServicesActions.createServiceFailure({
+                error: err.error?.message ?? 'Failed to create service',
+              }),
+            ),
+          ),
+        );
+      }),
+    ),
+  );
+
+  createServiceSuccess$ = createEffect(
+    () =>
+      this.actions$.pipe(
+        ofType(ServicesActions.createServiceSuccess),
+        tap(({ service }) =>
+          this.router.navigate(['/editor', service._id, 'calls']),
+        ),
+      ),
+    { dispatch: false },
+  );
+}

--- a/apps/frontend/src/app/services/store/services.reducer.ts
+++ b/apps/frontend/src/app/services/store/services.reducer.ts
@@ -1,0 +1,48 @@
+import { createReducer, on } from '@ngrx/store';
+import * as ServicesActions from './services.actions';
+import { initialServicesState } from './services.state';
+
+export const servicesReducer = createReducer(
+  initialServicesState,
+
+  on(ServicesActions.loadServices, (state) => ({
+    ...state,
+    loading: true,
+    error: null,
+  })),
+  on(ServicesActions.loadServicesSuccess, (state, { services }) => ({
+    ...state,
+    loading: false,
+    items: services,
+  })),
+  on(ServicesActions.loadServicesFailure, (state, { error }) => ({
+    ...state,
+    loading: false,
+    error,
+  })),
+
+  on(ServicesActions.saveService, (state) => ({
+    ...state,
+    saving: true,
+  })),
+  on(ServicesActions.saveServiceSuccess, (state, { service }) => ({
+    ...state,
+    saving: false,
+    items: state.items.map((i) => (i._id === service._id ? service : i)),
+  })),
+  on(ServicesActions.saveServiceFailure, (state, { error }) => ({
+    ...state,
+    saving: false,
+    error,
+  })),
+
+  on(ServicesActions.deleteServiceSuccess, (state, { id }) => ({
+    ...state,
+    items: state.items.filter((i) => i._id !== id),
+  })),
+
+  on(ServicesActions.createServiceSuccess, (state, { service }) => ({
+    ...state,
+    items: [...state.items, service],
+  })),
+);

--- a/apps/frontend/src/app/services/store/services.selectors.ts
+++ b/apps/frontend/src/app/services/store/services.selectors.ts
@@ -1,0 +1,29 @@
+import { createFeatureSelector, createSelector } from '@ngrx/store';
+import { ServicesState } from './services.state';
+
+export const selectServicesState =
+  createFeatureSelector<ServicesState>('services');
+
+export const selectServices = createSelector(
+  selectServicesState,
+  (s) => s.items,
+);
+export const selectServicesLoading = createSelector(
+  selectServicesState,
+  (s) => s.loading,
+);
+export const selectServicesSaving = createSelector(
+  selectServicesState,
+  (s) => s.saving,
+);
+export const selectServicesError = createSelector(
+  selectServicesState,
+  (s) => s.error,
+);
+
+export const selectStarredServices = createSelector(selectServices, (items) =>
+  items.filter((s) => s.starred),
+);
+export const selectOtherServices = createSelector(selectServices, (items) =>
+  items.filter((s) => !s.starred),
+);

--- a/apps/frontend/src/app/services/store/services.state.ts
+++ b/apps/frontend/src/app/services/store/services.state.ts
@@ -1,0 +1,17 @@
+import { IService } from '@virtualservice/shared/model';
+
+export type IServiceItem = IService & { _id: string };
+
+export interface ServicesState {
+  items: IServiceItem[];
+  loading: boolean;
+  saving: boolean;
+  error: string | null;
+}
+
+export const initialServicesState: ServicesState = {
+  items: [],
+  loading: false,
+  saving: false,
+  error: null,
+};

--- a/apps/frontend/src/styles.scss
+++ b/apps/frontend/src/styles.scss
@@ -28,6 +28,7 @@ html {
   --vs-accent-transp: #ff408150;
   --vs-warn-light: #f44336;
   --vs-warn: brown;
+  --vs-light-grey: #0a0a0a33;
 
   --toolbar-height-wide: 140px;
   --toolbar-height-narrow: 60px;


### PR DESCRIPTION
## Summary

- **Services Page** (`/services`): displays user's mock services in two sections (starred / others), with drag-over drop hint, loading state, and bottom FAB bar (help + add)
- **ServiceTileComponent**: `mat-card` tile with active toggle, delete confirmation dialog, star/monitor/swagger/OPEN actions, hover elevation, inactive diagonal pattern, responsive (250px wide / 220px+zoom in narrow)
- **Services NgRx store**: full CRUD feature — load/save/delete/create actions and effects; `selectStarredServices` / `selectOtherServices` selectors; `IServiceItem = IService & { _id: string }`
- **ToolbarService**: signal-based service; pages call `.set(commands)` on init and `.clear()` on destroy; toolbar renders them as icon buttons (wide) or a `more_vert` popup menu (narrow)
- **ToolbarComponent refactor**: removed `isLoggedIn` input; reads user from NgRx store; shows user email + page-injected commands on the right
- **Auth infrastructure**: `authGuard` (CanActivateFn), `authInterceptor` (adds Bearer JWT to all HTTP requests), `ConfirmDialogComponent`
- **logout$ effect** added to `AuthEffects` to navigate to `/login` on logout

## Test plan

- [ ] Login → redirects to `/services`
- [ ] `/services` without auth → redirects to `/login`
- [ ] Services list loads from `GET /api/services`
- [ ] Toggle active → `POST /api/services` with updated service
- [ ] Toggle starred → moves tile between sections
- [ ] Delete → confirmation dialog → `DELETE /api/services/:id` → tile removed
- [ ] Add button → creates new service → navigates to editor
- [ ] Toolbar shows user email + logout button; logout clears store and goes to login
- [ ] Narrow mode (≤ 800px): toolbar commands in `more_vert` menu, tiles zoom .8

🤖 Generated with [Claude Code](https://claude.com/claude-code)